### PR TITLE
Handles uncaught errors in ntlmProvider preCall.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "alternate XHR methods for ewsjs",
   "main": "src/index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "mocha ./test/ --exit"
   },
   "repository": {
     "type": "git",
@@ -26,6 +26,7 @@
   "devDependencies": {
     "@types/bluebird": "^3.0.36",
     "@types/node": "^6.0.52",
-    "@types/request": "^2.47.0"
+    "@types/request": "^2.47.0",
+    "mocha": "^6.0.2"
   }
 }

--- a/src/ntlmProvider.d.ts
+++ b/src/ntlmProvider.d.ts
@@ -1,4 +1,3 @@
-/// <reference types="bluebird" />
 import * as Promise from "bluebird";
 import { IXHROptions } from "./ews.partial";
 import { IProvider } from "./IProvider";

--- a/src/ntlmProvider.ts
+++ b/src/ntlmProvider.ts
@@ -44,7 +44,7 @@ export class NtlmProvider implements IProvider {
             workstation: options['workstation'] || '.',
             domain: this.domain,
         };
-        
+
         return new Promise<IXHROptions>((resolve, reject) => {
 
             //let type1msg = ntlm.createType1Message(ntlmOptions); //lack of v2
@@ -52,7 +52,7 @@ export class NtlmProvider implements IProvider {
             //     options["rejectUnauthorized"] = !this.allowUntrustedCertificate;
             // options["rejectUnauthorized"] = false;
             // }
-            
+
             // options.headers['User-Agent'] = 'foo';
 
             options.headers['Connection'] = 'keep-alive';
@@ -72,33 +72,37 @@ export class NtlmProvider implements IProvider {
             // console.log(opt.headers);
             // console.log(opt.headers.Connection);
             request(opt, (error, response, body) => {
-                if (error) {
-                    reject(error);
-                }
-                else {
-                    // let xhrResponse: XMLHttpRequest = <any>{
-                    //     response: body ? body.toString() : '',
-                    //     status: response.statusCode,
-                    //     //redirectCount: meta.redirectCount,
-                    //     headers: response.headers,
-                    //     finalUrl: response.url,
-                    //     responseType: '',
-                    //     statusText: response.statusMessage,
-                    // };
-                    if (!response.headers['www-authenticate'])
-                        throw new Error('www-authenticate not found on response of second request');
+                try {
+                    if (error) {
+                        reject(error);
+                    }
+                    else {
+                        // let xhrResponse: XMLHttpRequest = <any>{
+                        //     response: body ? body.toString() : '',
+                        //     status: response.statusCode,
+                        //     //redirectCount: meta.redirectCount,
+                        //     headers: response.headers,
+                        //     finalUrl: response.url,
+                        //     responseType: '',
+                        //     statusText: response.statusMessage,
+                        // };
+                        if (!response.headers['www-authenticate'])
+                            throw new Error('www-authenticate not found on response of second request');
 
-                    //let type2msg = ntlm.parseType2Message(res.headers['www-authenticate']); //httpntlm
-                    //let type3msg = ntlm.createType3Message(type2msg, ntlmOptions); //httpntlm
-                    let type2msg = decodeType2Message(response.headers['www-authenticate']); //with ntlm-client
-                    let type3msg = createType3Message(type2msg, ntlmOptions.username, ntlmOptions.password, ntlmOptions.workstation, ntlmOptions.domain); //with ntlm-client
+                        //let type2msg = ntlm.parseType2Message(res.headers['www-authenticate']); //httpntlm
+                        //let type3msg = ntlm.createType3Message(type2msg, ntlmOptions); //httpntlm
+                        let type2msg = decodeType2Message(response.headers['www-authenticate']); //with ntlm-client
+                        let type3msg = createType3Message(type2msg, ntlmOptions.username, ntlmOptions.password, ntlmOptions.workstation, ntlmOptions.domain); //with ntlm-client
 
-                    delete options.headers['authorization'] // 'fetch' has this wired addition with lower case, with lower case ntlm on server side fails
-                    delete options.headers['connection'] // 'fetch' has this wired addition with lower case, with lower case ntlm on server side fails
+                        delete options.headers['authorization'] // 'fetch' has this wired addition with lower case, with lower case ntlm on server side fails
+                        delete options.headers['connection'] // 'fetch' has this wired addition with lower case, with lower case ntlm on server side fails
 
-                    options.headers['Authorization'] = type3msg;
-                    options.headers['Connection'] = 'Close';
-                    resolve(options);
+                        options.headers['Authorization'] = type3msg;
+                        options.headers['Connection'] = 'Close';
+                        resolve(options);
+                    }
+                } catch (err) {
+                    reject(err);
                 }
             });
         });

--- a/test/test-ntlmProvider.js
+++ b/test/test-ntlmProvider.js
@@ -1,0 +1,20 @@
+const {XhrApi} = require('../src/');
+
+describe('NTLM Provider Tests', function() {
+    this.timeout(1000);
+
+     it('Error in preCall response handler properly rejects promise', function (done) {
+        const xhrApi = new XhrApi().useNtlmAuthentication('foo', 'bar');
+        const result = xhrApi.xhr({
+            type: 'GET',
+            url: 'https://outlook.office365.com/EWS/Exchange.asmx',  // This will cause decodeType2Message to fail
+            data: {},
+            headers: {},
+        }).then(function (result) {
+            done(new Error('Request unexpectedly succeeed.'));
+        }).catch(function (err) {
+            done();
+        });
+    });
+
+ });


### PR DESCRIPTION
This resolves Issue #4 

The nested promise is a little dangerous because any exception within the response handler that isn't caught properly will result in the promise never returning.

I've also included a mocha test (and added mocha to devDependencies)