### PR TITLE
v 1.4.0 use @ewsjs/ntlm-client

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ewsjs/xhr",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "description": "alternate XHR methods for ewsjs",
   "main": "src/index.js",
   "scripts": {
@@ -18,9 +18,9 @@
   "license": "MIT",
   "typings": "src/index.d.ts",
   "dependencies": {
+    "@ewsjs/ntlm-client": "^1.0.0",
     "bluebird": "^3.4.6",
     "fetch": "^1.0.1",
-    "ntlm-client": "git+https://git@github.com/gautamsi/node-ntlm-client.git",
     "request": "^2.88.0"
   },
   "devDependencies": {

--- a/src/ntlmAuthXhrApi.js
+++ b/src/ntlmAuthXhrApi.js
@@ -2,13 +2,10 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 var fetch_1 = require("fetch");
 var Promise = require("bluebird");
-var utils_1 = require("./utils");
+var ntlm_client_1 = require("@ewsjs/ntlm-client");
 var https_1 = require("https");
 var http_1 = require("http");
-var _a = require("ntlm-client"), createType1Message = _a.createType1Message, decodeType2Message = _a.decodeType2Message, createType3Message = _a.createType3Message; //ref: has NTLM v2 support // info: also possible to use this package in node.
-//var ntlm = require('httpntlm').ntlm; //removing httpntlm due to lack of NTLM v2
-// var HttpsAgent = require('agentkeepalive').HttpsAgent; // can use this instead of node internal http agent
-// var keepaliveAgent = new HttpsAgent(); // new HttpsAgent({ keepAliveMsecs :10000}); need to add more seconds to keepalive for debugging time. debugging is advised on basic auth only
+var utils_1 = require("./utils");
 /** @internal */
 var ntlmAuthXhrApi = /** @class */ (function () {
     function ntlmAuthXhrApi(username, password, allowUntrustedCertificate) {
@@ -124,8 +121,7 @@ var ntlmAuthXhrApi = /** @class */ (function () {
             domain: this.domain
         };
         return new Promise(function (resolve, reject) {
-            //let type1msg = ntlm.createType1Message(ntlmOptions); //lack of v2
-            var type1msg = createType1Message(ntlmOptions.workstation, ntlmOptions.domain); // alternate client - ntlm-client
+            var type1msg = ntlm_client_1.createType1Message(ntlmOptions.workstation, ntlmOptions.domain);
             options.headers['Authorization'] = type1msg;
             options.headers['Connection'] = 'keep-alive';
             fetch_1.fetchUrl(options.url, options, function (error, meta, body) {
@@ -148,10 +144,8 @@ var ntlmAuthXhrApi = /** @class */ (function () {
         }).then(function (res) {
             if (!res.headers['www-authenticate'])
                 throw new Error('www-authenticate not found on response of second request');
-            //let type2msg = ntlm.parseType2Message(res.headers['www-authenticate']); //httpntlm
-            //let type3msg = ntlm.createType3Message(type2msg, ntlmOptions); //httpntlm
-            var type2msg = decodeType2Message(res.headers['www-authenticate']); //with ntlm-client
-            var type3msg = createType3Message(type2msg, ntlmOptions.username, ntlmOptions.password, ntlmOptions.workstation, ntlmOptions.domain); //with ntlm-client
+            var type2msg = ntlm_client_1.decodeType2Message(res.headers['www-authenticate']);
+            var type3msg = ntlm_client_1.createType3Message(type2msg, ntlmOptions.username, ntlmOptions.password, ntlmOptions.workstation, ntlmOptions.domain); //with ntlm-client
             delete options.headers['authorization']; // 'fetch' has this wired addition with lower case, with lower case ntlm on server side fails
             delete options.headers['connection']; // 'fetch' has this wired addition with lower case, with lower case ntlm on server side fails
             options.headers['Authorization'] = type3msg;

--- a/src/ntlmProvider.js
+++ b/src/ntlmProvider.js
@@ -2,8 +2,8 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 var request = require("request");
 var Promise = require("bluebird");
+var ntlm_client_1 = require("@ewsjs/ntlm-client");
 var https_1 = require("https");
-var _a = require("ntlm-client"), createType1Message = _a.createType1Message, decodeType2Message = _a.decodeType2Message, createType3Message = _a.createType3Message; //ref: has NTLM v2 support // info: also possible to use this package in node.
 var NtlmProvider = /** @class */ (function () {
     function NtlmProvider(username, password) {
         this.username = null;
@@ -35,7 +35,7 @@ var NtlmProvider = /** @class */ (function () {
             options.headers['Connection'] = 'keep-alive';
             options["jar"] = true;
             options["agent"] = new https_1.Agent({ keepAlive: true, rejectUnauthorized: options.rejectUnauthorized });
-            var type1msg = createType1Message(ntlmOptions.workstation, ntlmOptions.domain); // alternate client - ntlm-client
+            var type1msg = ntlm_client_1.createType1Message(ntlmOptions.workstation, ntlmOptions.domain); // alternate client - ntlm-client
             var opt = Object.assign({}, options);
             opt['method'] = "GET";
             opt.headers['Authorization'] = type1msg;
@@ -48,8 +48,8 @@ var NtlmProvider = /** @class */ (function () {
                     else {
                         if (!response.headers['www-authenticate'])
                             throw new Error('www-authenticate not found on response of second request');
-                        var type2msg = decodeType2Message(response.headers['www-authenticate']);
-                        var type3msg = createType3Message(type2msg, ntlmOptions.username, ntlmOptions.password, ntlmOptions.workstation, ntlmOptions.domain);
+                        var type2msg = ntlm_client_1.decodeType2Message(response.headers['www-authenticate']);
+                        var type3msg = ntlm_client_1.createType3Message(type2msg, ntlmOptions.username, ntlmOptions.password, ntlmOptions.workstation, ntlmOptions.domain);
                         delete options.headers['authorization']; // 'fetch' has this wired addition with lower case, with lower case ntlm on server side fails
                         delete options.headers['connection']; // 'fetch' has this wired addition with lower case, with lower case ntlm on server side fails
                         options.headers['Authorization'] = type3msg;

--- a/src/ntlmProvider.ts
+++ b/src/ntlmProvider.ts
@@ -1,12 +1,11 @@
 import * as request from 'request';
 import * as  Promise from "bluebird";
-import { IXHROptions } from "./ews.partial";
-
-import { IProvider } from "./IProvider";
-
+import { createType1Message, decodeType2Message, createType3Message } from "@ewsjs/ntlm-client";
 import { Agent as httpsAgent } from "https";
 
-var { createType1Message, decodeType2Message, createType3Message } = require("ntlm-client") //ref: has NTLM v2 support // info: also possible to use this package in node.
+import { IXHROptions } from "./ews.partial";
+import { IProvider } from "./IProvider";
+
 
 export class NtlmProvider implements IProvider {
 


### PR DESCRIPTION
* now use @ewsjs/ntlm-client instead of git hash

closes gautamsi/ews-javascript-api#309