### PR TITLE
chore: quieten down the console.log

### DIFF
--- a/dist/xhrApi.js
+++ b/dist/xhrApi.js
@@ -120,7 +120,6 @@ class XhrApi {
                 client = this.authProvider.client || client;
             }
             const opt = await _promise;
-            console.log("in xhr");
             // console.log({ opt });
             const response = await client(opt || options);
             // if (error) {

--- a/src/xhrApi.ts
+++ b/src/xhrApi.ts
@@ -159,7 +159,6 @@ export class XhrApi implements IXHRApi {
         client = this.authProvider.client || client;
       }
       const opt = await _promise;
-      console.log("in xhr");
       // console.log({ opt });
       const response = await client(opt || options as any);
 


### PR DESCRIPTION
There is a console.log in the main object and it is spitting out a lot of logs that are not needed. This PR deletes the one line.